### PR TITLE
Rename the topdir/migroose.js to migroose-connector.js

### DIFF
--- a/cli/runner/index.js
+++ b/cli/runner/index.js
@@ -43,7 +43,7 @@ Runner.prototype.getMigrations = function(){
 };
 
 Runner.prototype.openConnection = function(cb){
-  var migrooseFile = path.join(this.cwd, "migroose.js");
+  var migrooseFile = path.join(this.cwd, "migroose-connector.js");
   var connector = require(migrooseFile);
   connector.connect(cb);
 };

--- a/readme.md
+++ b/readme.md
@@ -37,13 +37,13 @@ connection to your MongoDB database. This only has to be done
 once per project, but it must be done before the migrations 
 can run.
 
-Create a `migroose.js` file in your project folder, and
+Create a `migroose-connector.js` file in your project folder, and
 have it export a `connect` function. This function receives
 one callback argument that you must call once your database
 connection has been established.
 
 ```js
-// my-project/migroose.js
+// my-project/migroose-connector.js
 
 var mongoose = require("mongoose");
 


### PR DESCRIPTION
This is Windows specific problem.

On Windows, the "npm start" invoke the ./migroose.js by mistake instead of "node_modules/.bin/migroose.cmd"

The steps to reproduce are below.

```
mkdir sample.app
cd sample.app

npm install migroose
npm install migroose-cli

mkdir migrootions

touch migroose.js

cat > package.json
{
  "name": "sample.app",
  "scripts": {
    "start": "echo start",
    "prestart": "migroose"
  }
}
^D

npm start  
=> invoke the ./migroose.js instead of "node_modules/.bin/migroose.cmd"
```
